### PR TITLE
Delete gh-pages-push.sh

### DIFF
--- a/gh-pages-push.sh
+++ b/gh-pages-push.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-read -p "Are you SURE you want to delete your remote gh-pages branch and replace it with a fresh one? " -n 1 -r
-echo    # (optional) move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-	git subtree push --prefix public origin gh-pages-temp
-	git push --force origin origin/gh-pages-temp:refs/heads/gh-pages :gh-pages-temp
-fi


### PR DESCRIPTION
This script is no longer necessary: GitHub Pages can now be published from the master branch (when configured as such in repository settings)