### PR TITLE
Fix broken dependency by pinning vue-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "font-awesome": "^4.7.0",
     "three": "0.82.1",
     "vue": "^2.4.2",
-    "vue-cli": "^2.8.2"
+    "vue-cli": "2.8.2"
   },
   "devDependencies": {
     "push-dir": "^0.4.1"


### PR DESCRIPTION
This avoids the following error message, introduced in v2.9.0:

>We are slimming down vue-cli to optimize the initial installation by removing the `vue build` command.
>Check out Poi (https://github.com/egoist/poi) which offers the same functionality!